### PR TITLE
target player when camera is from dialogue target

### DIFF
--- a/src/DOFManager.cpp
+++ b/src/DOFManager.cpp
@@ -31,6 +31,13 @@ float DOFManager::GetDistanceToDialogueTarget()
 	} else {
 		target = RE::MenuTopicManager::GetSingleton()->lastSpeaker.get().get();
 	}
+	/* In Alternate Conversation Camera with the speaker swap setting enabled,
+	 * the camera switches to focus on the player after the NPC stops speaking
+	 * and waits for the player's response. At this time, the PlayerCamera
+	 * cameraTarget is the NPC being conversed with instead of the player. */
+	if (   RE::PlayerCamera::GetSingleton()->cameraTarget
+	    && RE::PlayerCamera::GetSingleton()->cameraTarget.get().get() == target)
+		target = RE::PlayerCharacter::GetSingleton();
 	RE::NiPoint3 cameraPosition = GetCameraPos();
 	RE::NiPoint3 targetPosition = target->GetPosition();
 	return cameraPosition.GetDistance(targetPosition);
@@ -73,7 +80,7 @@ void DOFManager::UpdateDOF(float a_delta)
 	if (targetFocusEnabled)
 		targetFocusDistanceENB = static_cast<float>(targetFocusDistanceGame / 70.0280112 / 1000);
 
-	targetFocusPercent = std::lerp(targetFocusPercent, targetFocusEnabled, a_delta);
+	targetFocusPercent = (float)std::lerp(targetFocusPercent, targetFocusEnabled, a_delta);
 
 	if (auto scriptFactory = RE::IFormFactory::GetConcreteFormFactoryByType<RE::Script>()) {
 		if (auto script = scriptFactory->Create()) {


### PR DESCRIPTION
Hi, hope you are doing well.

Improved Alternate Conversation Camera has a setting where it can switch the camera to look at the player from over the shoulder of the NPC when the NPC has finished speaking and the player is selecting their dialogue. From this perspective, it looks more appropriate for the DOF target to be the player.

From what I can tell, the conversation camera mod sets the player camera target to the NPC when this happens. So this modifies skyrim-target-focus to check for that and, in that case, returns camera depth to the player instead of the NPC in conversation.

I used it and it seemed to work fine but I don't know commonlib stuff so ¯\\\_(ツ)\_/¯

before & after
![SkyrimSE_before](https://github.com/user-attachments/assets/b0e86c88-cf9b-4196-9d30-45f1166cebb8)
![SkyrimSE_after](https://github.com/user-attachments/assets/f8bab379-9625-4dff-a77a-701a334af3bb)
